### PR TITLE
phase_rare: haplotype_writer: remove missing flag on imputed variants

### DIFF
--- a/phase_rare/src/io/haplotype_writer.cpp
+++ b/phase_rare/src/io/haplotype_writer.cpp
@@ -205,8 +205,10 @@ void haplotype_writer::writeHaplotypesXCF(std::string foutput, std::string finpu
 
 				if (fformat == "pp") {
 					for (int32_t i = 0 ; i < G.GRvar_genotypes[vr].size() ; i++) {
-						
-						output_buffer[n_sparse++] = G.GRvar_genotypes[vr][i].get();
+						sparse_genotype sg;
+						sg.set(G.GRvar_genotypes[vr][i].get());
+						sg.mis = false;
+						output_buffer[n_sparse++] = sg.get();
 					}
 					for (int32_t i = 0 ; i < G.GRvar_genotypes[vr].size() ; i++) {
 						output_buffer[n_sparse++] = bit_cast<uint32_t> (G.GRvar_genotypes[vr][i].prob);


### PR DESCRIPTION
Sparse genotypes for imputed variants have the missing flag until the end, in the writeHaplotypeVCF() function only the alleles and probability are carried over to the VCF record, not the "missing flag".

However with writeHaplotyeXCF() the sparse genotypes are directly written in the binary file and therefore carry over any flag. Therefore remove the missing flag in the sparse genotypes that still have it (i.e., imputed genotypes).